### PR TITLE
[GAME] [MODIFY] removed IOT crash

### DIFF
--- a/Game/GameState.cpp
+++ b/Game/GameState.cpp
@@ -20,7 +20,6 @@ GameState::GameState(StateMachine &t_machine, rtype::IRenderWindow *t_window,
   m_music_player.play(MusicID::MISSION_THEME);
   std::shared_ptr<EntityManager> entity_manager =
     std::make_shared<EntityManager>(initEntityManager());
-  //   std::vector<std::shared_ptr<ISystem>> systems = initSystems(entity_manager);
   m_systems = initSystems(entity_manager);
 }
 

--- a/GameEngine/src/Core.cpp
+++ b/GameEngine/src/Core.cpp
@@ -7,8 +7,12 @@ Core::Core(std::size_t t_flag) {
     static_cast<rtype::Style>(rtype::Style::Titlebar | rtype::Style::Close));
   m_window->setFramerateLimit(30);
 
-  m_state_machine.run(StateMachine::build<MainState>(
-    m_state_machine, m_window, m_music_player, t_flag, true));
+  if (t_flag == 1)
+    m_state_machine.run(StateMachine::build<MainState>(
+      m_state_machine, m_window, m_music_player, t_flag, true));
+  else
+    m_state_machine.run(StateMachine::build<GameState>(
+      m_state_machine, m_window, m_music_player, t_flag, true));
 }
 
 Core::~Core() {}

--- a/GameEngine/src/MusicPlayer.cpp
+++ b/GameEngine/src/MusicPlayer.cpp
@@ -8,6 +8,8 @@ MusicPlayer::MusicPlayer() : m_volume(100.f) {
   m_music->setVolume(m_volume);
 }
 
+MusicPlayer::~MusicPlayer() { delete m_music; }
+
 void MusicPlayer::play(MusicID t_theme) { m_music->play(t_theme); }
 
 void MusicPlayer::stop() { m_music->stop(); }

--- a/GameEngine/src/MusicPlayer.hpp
+++ b/GameEngine/src/MusicPlayer.hpp
@@ -15,6 +15,7 @@ enum MusicID {
 class MusicPlayer {
  public:
   MusicPlayer();
+  ~MusicPlayer();
   void play(MusicID t_theme);
   void stop();
   void setPaused(bool t_paused);


### PR DESCRIPTION
# Motivation:

When game was closed, it resulted in an IOT instruction (core crashed) error and 1 device was not closed.

# Modifications:

Added a deconstructor to the MusicPlayer.

# Result:

Now everything gets closed properly and the program doesn't crash anymore.