### PR TITLE
[GAME] [ADD] created graphic loader for all sfml creations

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -64,7 +64,9 @@ set(CLIENT_HPP ../Game/ECS/ComponentPool.hpp
         ../GameEngine/src/States/SettingsState.hpp
         ../Game/Encapsulation/IMouse.hpp
         ../Game/Encapsulation/SFML/Mouse.hpp
-        ../Game/Systems/CreatePlayerSystem.hpp)
+        ../Game/Systems/CreatePlayerSystem.hpp
+        ../Game/Encapsulation/IGraphicLoader.hpp
+        ../Game/Encapsulation/SFML/GraphicLoader.hpp)
 
 set(CLIENT_SRC ../Game/Systems/DisplaySystem.cpp
         src/InputManager/InputManager.cpp
@@ -112,7 +114,8 @@ set(CLIENT_SRC ../Game/Systems/DisplaySystem.cpp
         ../GameEngine/src/States/MainState.cpp
         ../GameEngine/src/States/SettingsState.cpp
         ../Game/Encapsulation/SFML/Mouse.cpp
-        ../Game/Systems/CreatePlayerSystem.cpp)
+        ../Game/Systems/CreatePlayerSystem.cpp
+        ../Game/Encapsulation/SFML/GraphicLoader.cpp)
 
 include(FetchContent)
 FetchContent_Declare(SFML

--- a/Game/CreateEntities/Init.cpp
+++ b/Game/CreateEntities/Init.cpp
@@ -3,20 +3,22 @@
 #include <vector>
 
 EntityID initPlayer(std::shared_ptr<EntityManager> t_entity_manager,
-                    UdpServer *t_serverCom) {
+                    UdpServer *t_serverCom,
+                    rtype::IGraphicLoader *t_graphic_loader) {
   EntityID player = t_entity_manager->createNewEntity();
 
-  SpriteECS player_sprite = SpriteECS("../Client/sprites/starship.png");
+  SpriteECS player_sprite =
+    SpriteECS("../Client/sprites/starship.png", t_graphic_loader);
 
   Pos player_pos = Pos{rtype::Vector2f{0.0, 0.0}, rtype::Vector2f{300, 300}};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = t_graphic_loader->loadRectangleShape();
   body->setSize({200, 200});
   body->setPosition({player_pos.position.x, player_pos.position.y});
   body->setTexture(player_sprite.getTexture());
   body->setRotation(90.0);
 
-  Health health = initPlayerHealthBar();
+  Health health = initPlayerHealthBar(t_graphic_loader);
   Player player_obj = Player{player_sprite, player_pos, body, health, 10};
   t_entity_manager->Assign<Player>(player, player_obj);
   t_serverCom->addEvent(std::make_shared<Action>(
@@ -25,32 +27,33 @@ EntityID initPlayer(std::shared_ptr<EntityManager> t_entity_manager,
   return player;
 }
 
-void initBackground(EntityManager &t_entity_manager) {
+void initBackground(EntityManager &t_entity_manager,
+                    rtype::IGraphicLoader *t_graphic_loader) {
   // background layer 1
   EntityID background1 = t_entity_manager.createNewEntity();
-  BackgroundLayer background_layer1 =
-    BackgroundLayer{SpriteECS("../Client/sprites/background/bg1.png", {5, 5}),
-                    rtype::Vector2f{0, 0}, 1, (-272 * 5)};
+  BackgroundLayer background_layer1 = BackgroundLayer{
+    SpriteECS("../Client/sprites/background/bg1.png", t_graphic_loader, {5, 5}),
+    rtype::Vector2f{0, 0}, 1, (-272 * 5)};
   t_entity_manager.Assign<BackgroundLayer>(background1, background_layer1);
 
   // background layer 2
   EntityID background2 = t_entity_manager.createNewEntity();
-  BackgroundLayer background_layer2 =
-    BackgroundLayer{SpriteECS("../Client/sprites/background/bg2.png", {4, 4}),
-                    rtype::Vector2f{0, 160}, 2, (-272 * 10)};
+  BackgroundLayer background_layer2 = BackgroundLayer{
+    SpriteECS("../Client/sprites/background/bg2.png", t_graphic_loader, {4, 4}),
+    rtype::Vector2f{0, 160}, 2, (-272 * 10)};
   t_entity_manager.Assign<BackgroundLayer>(background2, background_layer2);
 
   // background layer 3
   EntityID background3 = t_entity_manager.createNewEntity();
-  BackgroundLayer background_layer3 =
-    BackgroundLayer{SpriteECS("../Client/sprites/background/bg3.png", {5, 5}),
-                    rtype::Vector2f{0, 0}, 3, (-272 * 5)};
+  BackgroundLayer background_layer3 = BackgroundLayer{
+    SpriteECS("../Client/sprites/background/bg3.png", t_graphic_loader, {5, 5}),
+    rtype::Vector2f{0, 0}, 3, (-272 * 5)};
   t_entity_manager.Assign<BackgroundLayer>(background3, background_layer3);
 }
 
-Health initPlayerHealthBar() {
+Health initPlayerHealthBar(rtype::IGraphicLoader *t_graphic_loader) {
   SpriteECS player_health_bar_sprite_full =
-    SpriteECS("../Client/sprites/playerassets/Fulllife.png");
+    SpriteECS("../Client/sprites/playerassets/Fulllife.png", t_graphic_loader);
 
   Pos bar_pos = Pos{rtype::Vector2f{0, 0}, rtype::Vector2f{120, 230}};
 
@@ -62,7 +65,7 @@ Health initPlayerHealthBar() {
                 std::string("../Client/sprites/playerassets/Fulllife.png")},
               3};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = t_graphic_loader->loadRectangleShape();
   body->setSize({126, 42});
   body->setPosition({bar_pos.position.x, bar_pos.position.y});
   body->setTexture(player_health_bar_sprite_full.getTexture());

--- a/Game/CreateEntities/Init.hpp
+++ b/Game/CreateEntities/Init.hpp
@@ -5,13 +5,15 @@
 #include "../../Server/Protocol/UdpServer.hpp"
 #include "../Encapsulation/GraphicDataTypes.hpp"
 #include "../Encapsulation/IRectangleShape.hpp"
-#include "../Encapsulation/SFML/RectangleShape.hpp"
+#include "../Encapsulation/IGraphicLoader.hpp"
 
 EntityID initPlayer(std::shared_ptr<EntityManager> t_entity_manager,
-                    UdpServer *t_serverCom);
+                    UdpServer *t_serverCom,
+                    rtype::IGraphicLoader *t_graphic_loader);
 void initEnemy();
 void initBullet();
-void initBackground(EntityManager &t_entity_manager);
-Health initPlayerHealthBar();
+void initBackground(EntityManager &t_entity_manager,
+                    rtype::IGraphicLoader *t_graphic_loader);
+Health initPlayerHealthBar(rtype::IGraphicLoader *t_graphic_loader);
 
 #endif  //R_TYPE_CLIENT_INIT_HPP

--- a/Game/ECS/DataTypesECS.hpp
+++ b/Game/ECS/DataTypesECS.hpp
@@ -6,10 +6,9 @@
 #include <vector>
 #include "../Encapsulation/GraphicDataTypes.hpp"
 #include "../Encapsulation/ITexture.hpp"
-#include "../Encapsulation/SFML/Texture.hpp"
 #include "../Encapsulation/ISprite.hpp"
-#include "../Encapsulation/SFML/Sprite.hpp"
 #include "../Encapsulation/IRectangleShape.hpp"
+#include "../Encapsulation/IGraphicLoader.hpp"
 #include "../EventQueue.hpp"
 
 struct AnimationTime {
@@ -65,9 +64,10 @@ struct Health {
 
 class SpriteECS {
  public:
-  SpriteECS(std::string t_sprite_path, rtype::Vector2f t_scale = {1, 1}) {
-    m_sprite = new rtype::Sprite();
-    m_texture = new rtype::Texture();
+  SpriteECS(std::string t_sprite_path, rtype::IGraphicLoader *t_graphic_loader,
+            rtype::Vector2f t_scale = {1, 1}) {
+    m_sprite = t_graphic_loader->loadSprite();
+    m_texture = t_graphic_loader->loadTexture();
     m_texture->loadFromFile(t_sprite_path);
     m_sprite->setTexture(m_texture);
     m_sprite->setScale({t_scale.x, t_scale.y});

--- a/Game/ECS/ISystem.hpp
+++ b/Game/ECS/ISystem.hpp
@@ -6,7 +6,7 @@
 #include "DataTypesECS.hpp"
 #include "../Encapsulation/GraphicDataTypes.hpp"
 #include "../Encapsulation/IRectangleShape.hpp"
-#include "../Encapsulation/SFML/RectangleShape.hpp"
+#include "../Encapsulation/IGraphicLoader.hpp"
 
 class ISystem {
  public:

--- a/Game/Encapsulation/IGraphicLoader.hpp
+++ b/Game/Encapsulation/IGraphicLoader.hpp
@@ -1,0 +1,27 @@
+#ifndef R_TYPE_CLIENT_IGRAPHICLOADER_HPP
+#define R_TYPE_CLIENT_IGRAPHICLOADER_HPP
+
+#include "IMouse.hpp"
+#include "IMusic.hpp"
+#include "IRectangleShape.hpp"
+#include "IRenderWindow.hpp"
+#include "ISounds.hpp"
+#include "ISprite.hpp"
+#include "ITexture.hpp"
+
+namespace rtype {
+  class IGraphicLoader {
+   public:
+    virtual ~IGraphicLoader() = default;
+
+    virtual rtype::IMouse *loadMouse() = 0;
+    virtual rtype::IMusic *loadMusic() = 0;
+    virtual rtype::IRectangleShape *loadRectangleShape() = 0;
+    virtual rtype::IRenderWindow *loadRenderWindow() = 0;
+    virtual rtype::ISounds *loadSound() = 0;
+    virtual rtype::ISprite *loadSprite() = 0;
+    virtual rtype::ITexture *loadTexture() = 0;
+  };
+}  // namespace rtype
+
+#endif  //R_TYPE_CLIENT_IGRAPHICLOADER_HPP

--- a/Game/Encapsulation/SFML/GraphicLoader.cpp
+++ b/Game/Encapsulation/SFML/GraphicLoader.cpp
@@ -1,0 +1,19 @@
+#include "GraphicLoader.hpp"
+
+rtype::IMouse *rtype::GraphicLoader::loadMouse() { return new Mouse(); }
+
+rtype::IMusic *rtype::GraphicLoader::loadMusic() { return new Music(); }
+
+rtype::IRectangleShape *rtype::GraphicLoader::loadRectangleShape() {
+  return new RectangleShape();
+}
+
+rtype::IRenderWindow *rtype::GraphicLoader::loadRenderWindow() {
+  return new RenderWindow();
+}
+
+rtype::ISounds *rtype::GraphicLoader::loadSound() { return new Sounds(); }
+
+rtype::ISprite *rtype::GraphicLoader::loadSprite() { return new Sprite(); }
+
+rtype::ITexture *rtype::GraphicLoader::loadTexture() { return new Texture(); }

--- a/Game/Encapsulation/SFML/GraphicLoader.hpp
+++ b/Game/Encapsulation/SFML/GraphicLoader.hpp
@@ -1,0 +1,30 @@
+#ifndef R_TYPE_CLIENT_GRAPHICLOADER_HPP
+#define R_TYPE_CLIENT_GRAPHICLOADER_HPP
+
+#include "../IGraphicLoader.hpp"
+
+#include "./Mouse.hpp"
+#include "./Music.hpp"
+#include "./RectangleShape.hpp"
+#include "./RenderWindow.hpp"
+#include "./Sounds.hpp"
+#include "./Sprite.hpp"
+#include "./Texture.hpp"
+
+namespace rtype {
+  class GraphicLoader : public IGraphicLoader {
+   public:
+    GraphicLoader() = default;
+    ~GraphicLoader() override = default;
+
+    IMouse *loadMouse() override;
+    IMusic *loadMusic() override;
+    IRectangleShape *loadRectangleShape() override;
+    IRenderWindow *loadRenderWindow() override;
+    ISounds *loadSound() override;
+    ISprite *loadSprite() override;
+    ITexture *loadTexture() override;
+  };
+}  // namespace rtype
+
+#endif  //R_TYPE_CLIENT_GRAPHICLOADER_HPP

--- a/Game/GameState.cpp
+++ b/Game/GameState.cpp
@@ -35,7 +35,7 @@ GameState::~GameState() {
 
 EntityManager GameState::initEntityManager() {
   EntityManager entity_manager;
-  initBackground(entity_manager);
+  initBackground(entity_manager, m_graphic_loader);
   return entity_manager;
 }
 
@@ -44,28 +44,30 @@ GameState::initSystems(std::shared_ptr<EntityManager> entity_manager) {
   std::vector<std::shared_ptr<ISystem>> systems;
 
   if (m_flag == CommunicationFlag::server) {
-    systems.push_back(
-      std::make_shared<CreatePlayerSystem>(entity_manager, m_serverCom));
+    systems.push_back(std::make_shared<CreatePlayerSystem>(
+      entity_manager, m_serverCom, m_graphic_loader));
     systems.push_back(std::make_shared<RandomEnemyGeneratorSystem>(
-      entity_manager, m_serverCom));
+      entity_manager, m_serverCom, m_graphic_loader));
     systems.push_back(
       std::make_shared<CollisionSystem>(entity_manager, m_serverCom));
-    systems.push_back(
-      std::make_shared<ShootingSystem>(entity_manager, m_serverCom));
+    systems.push_back(std::make_shared<ShootingSystem>(
+      entity_manager, m_serverCom, m_graphic_loader));
     systems.push_back(
       std::make_shared<MovementSystem>(entity_manager, m_serverCom));
   } else {
     systems.push_back(std::make_shared<DamageSystem>(
-      entity_manager, m_input_manager, m_port_number, m_is_running, m_sounds));
-    systems.push_back(
-      std::make_shared<CreateObjectSystem>(entity_manager, m_sounds));
+      entity_manager, m_input_manager, m_port_number, m_is_running, m_sounds,
+      m_graphic_loader));
+    systems.push_back(std::make_shared<CreateObjectSystem>(
+      entity_manager, m_sounds, m_graphic_loader));
     systems.push_back(
       std::make_shared<MovementSystem>(entity_manager, nullptr));
     systems.push_back(
       std::make_shared<AnimationSystem>(entity_manager, m_input_manager));
-    systems.push_back(
-      std::make_shared<PowerUpSystem>(entity_manager, m_sounds));
-    systems.push_back(std::make_shared<SoundSystem>(entity_manager, m_sounds));
+    systems.push_back(std::make_shared<PowerUpSystem>(entity_manager, m_sounds,
+                                                      m_graphic_loader));
+    systems.push_back(std::make_shared<SoundSystem>(entity_manager, m_sounds,
+                                                    m_graphic_loader));
   }
   systems.push_back(std::make_shared<DisplaySystem>(entity_manager, m_window));
   systems.push_back(std::make_shared<DestroySystem>(entity_manager));

--- a/Game/GameState.cpp
+++ b/Game/GameState.cpp
@@ -2,9 +2,11 @@
 
 GameState::GameState(StateMachine &t_machine, rtype::IRenderWindow *t_window,
                      MusicPlayer &t_music_player, std::size_t t_flag,
+                     rtype::IGraphicLoader *t_graphic_loader,
                      const bool t_replace)
-    : State{t_machine, t_window, t_music_player, t_replace} {
+    : State{t_machine, t_window, t_music_player, t_graphic_loader, t_replace} {
   m_is_running = true;
+  m_graphic_loader = t_graphic_loader;
   if (t_flag == client) {
     m_flag = CommunicationFlag::client;
     m_port_number = rand() % 15000 + 40001;

--- a/Game/GameState.hpp
+++ b/Game/GameState.hpp
@@ -38,7 +38,7 @@ class GameState final : public State {
  public:
   GameState(StateMachine &t_machine, rtype::IRenderWindow *t_window,
             MusicPlayer &t_music_player, std::size_t t_flag,
-            bool t_replace = true);
+            rtype::IGraphicLoader *t_graphic_loader, bool t_replace = true);
   ~GameState();
 
   void pause() override;

--- a/Game/Systems/CreateObjectSystem.cpp
+++ b/Game/Systems/CreateObjectSystem.cpp
@@ -2,9 +2,11 @@
 
 CreateObjectSystem::CreateObjectSystem(
   std::shared_ptr<EntityManager> t_em,
-  std::vector<SoundSystem::SoundType> &t_sounds)
+  std::vector<SoundSystem::SoundType> &t_sounds,
+  rtype::IGraphicLoader *t_graphic_loader)
     : m_play_sounds(t_sounds) {
   m_em = t_em;
+  m_graphic_loader = t_graphic_loader;
 }
 
 CreateObjectSystem::~CreateObjectSystem() {}
@@ -50,11 +52,11 @@ void CreateObjectSystem::update() {
 void CreateObjectSystem::createPlayer(EntityID t_id, std::string t_sprite_path,
                                       rtype::Vector2f t_pos) {
   EntityID player = m_em->createNewEntity(t_id);
-  SpriteECS player_sprite = SpriteECS(t_sprite_path);
+  SpriteECS player_sprite = SpriteECS(t_sprite_path, m_graphic_loader);
 
   Pos player_pos = Pos{rtype::Vector2f{0, 0}, t_pos};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({200, 200});
   body->setPosition({player_pos.position.x, player_pos.position.y});
   body->setTexture(player_sprite.getTexture());
@@ -68,7 +70,7 @@ void CreateObjectSystem::createPlayer(EntityID t_id, std::string t_sprite_path,
 
 Health CreateObjectSystem::initPlayerHealthBar(EntityID t_player_id) {
   SpriteECS player_health_bar_sprite_full =
-    SpriteECS("../Client/sprites/playerassets/Fulllife.png");
+    SpriteECS("../Client/sprites/playerassets/Fulllife.png", m_graphic_loader);
 
   Pos bar_pos = Pos{rtype::Vector2f{0, 0}, rtype::Vector2f{120, 230}};
 
@@ -80,7 +82,7 @@ Health CreateObjectSystem::initPlayerHealthBar(EntityID t_player_id) {
                 std::string("../Client/sprites/playerassets/Fulllife.png")},
               3};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({126, 42});
   body->setPosition({bar_pos.position.x, bar_pos.position.y});
   body->setTexture(player_health_bar_sprite_full.getTexture());
@@ -92,22 +94,25 @@ void CreateObjectSystem::createBullet(EntityID t_id, rtype::Vector2f t_pos,
                                       Action::ShootingType t_shooting_type) {
   EntityID bullet = m_em->createNewEntity(t_id);
 
-  rtype::IRectangleShape *bullet_body = new rtype::RectangleShape();
+  rtype::IRectangleShape *bullet_body = m_graphic_loader->loadRectangleShape();
   bullet_body->setSize({20, 20});
   bullet_body->setPosition({t_pos.x, t_pos.y});
 
   switch (t_shooting_type) {
     case Action::ShootingType::NORMAL:
       bullet_body->setTexture(
-        SpriteECS("./../Client/sprites/shoot2.png").getTexture());
+        SpriteECS("./../Client/sprites/shoot2.png", m_graphic_loader)
+          .getTexture());
       break;
     case Action::ShootingType::FIRE:
       bullet_body->setTexture(
-        SpriteECS("./../Client/sprites/shoot3.png").getTexture());
+        SpriteECS("./../Client/sprites/shoot3.png", m_graphic_loader)
+          .getTexture());
       break;
     case Action::ShootingType::BOMB:
       bullet_body->setTexture(
-        SpriteECS("./../Client/sprites/shoot4.png").getTexture());
+        SpriteECS("./../Client/sprites/shoot4.png", m_graphic_loader)
+          .getTexture());
       break;
   }
 
@@ -120,8 +125,9 @@ void CreateObjectSystem::createBullet(EntityID t_id, rtype::Vector2f t_pos,
 void CreateObjectSystem::createEnemy(EntityID t_id, rtype::Vector2f t_pos,
                                      float t_velocity) {
   EntityID enemy = m_em->createNewEntity(t_id);
-  SpriteECS sprite = SpriteECS("./../Client/sprites/r-typesheet30a.gif");
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/r-typesheet30a.gif", m_graphic_loader);
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({30, 30});
   body->setPosition({t_pos.x, t_pos.y});
   body->setTexture(sprite.getTexture());
@@ -138,8 +144,9 @@ void CreateObjectSystem::createEnemy(EntityID t_id, rtype::Vector2f t_pos,
 
 void CreateObjectSystem::createExplosion(EntityID t_id, rtype::Vector2f t_pos) {
   EntityID explosion = m_em->createNewEntity(t_id);
-  SpriteECS sprite = SpriteECS("./../Client/sprites/explosion/Explosion.png");
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/explosion/Explosion.png", m_graphic_loader);
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({50, 50});
   body->setPosition({t_pos.x, t_pos.y});
   body->setTexture(sprite.getTexture());
@@ -158,8 +165,9 @@ void CreateObjectSystem::createExplosion(EntityID t_id, rtype::Vector2f t_pos) {
 
 void CreateObjectSystem::createPowerUp(EntityID t_id, rtype::Vector2f t_pos) {
   EntityID powerup = m_em->createNewEntity(t_id);
-  SpriteECS sprite = SpriteECS("./../Client/sprites/powerup/coin.png");
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/powerup/coin.png", m_graphic_loader);
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({30, 30});
   body->setPosition({t_pos.x, t_pos.y});
   body->setTexture(sprite.getTexture());
@@ -199,11 +207,11 @@ void CreateObjectSystem::createItem(EntityID t_id, rtype::ItemType t_item_type,
       break;
   }
   EntityID item = m_em->createNewEntity(t_id);
-  SpriteECS item_sprite = SpriteECS(path);
+  SpriteECS item_sprite = SpriteECS(path, m_graphic_loader);
 
   Pos player_pos = Pos{rtype::Vector2f{-7, 0}, t_pos};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({40, 40});
   body->setOrigin({20, 20});
   body->setPosition({player_pos.position.x, player_pos.position.y});

--- a/Game/Systems/CreateObjectSystem.hpp
+++ b/Game/Systems/CreateObjectSystem.hpp
@@ -12,7 +12,8 @@
 class CreateObjectSystem : public ISystem {
  public:
   CreateObjectSystem(std::shared_ptr<EntityManager> t_em,
-                     std::vector<SoundSystem::SoundType> &t_sounds);
+                     std::vector<SoundSystem::SoundType> &t_sounds,
+                     rtype::IGraphicLoader *t_graphic_loader);
   ~CreateObjectSystem();
 
   void update();
@@ -22,6 +23,7 @@ class CreateObjectSystem : public ISystem {
   std::shared_ptr<EntityManager> m_em;
   EventQueue m_event_queue;
   std::vector<SoundSystem::SoundType> &m_play_sounds;
+  rtype::IGraphicLoader *m_graphic_loader;
 
   void createPlayer(EntityID t_id, std::string t_sprite_path,
                     rtype::Vector2f t_pos);

--- a/Game/Systems/CreatePlayerSystem.cpp
+++ b/Game/Systems/CreatePlayerSystem.cpp
@@ -1,9 +1,11 @@
 #include "./CreatePlayerSystem.hpp"
 
-CreatePlayerSystem::CreatePlayerSystem(std::shared_ptr<EntityManager> t_em,
-                                       UdpServer *t_server_com) {
+CreatePlayerSystem::CreatePlayerSystem(
+  std::shared_ptr<EntityManager> t_em, UdpServer *t_server_com,
+  rtype::IGraphicLoader *t_graphic_loader) {
   m_em = t_em;
   m_server_com = t_server_com;
+  m_graphic_loader = t_graphic_loader;
 }
 
 void CreatePlayerSystem::updateData(SystemData &t_data) {
@@ -23,7 +25,7 @@ void CreatePlayerSystem::update() {
        m_event_queue.getAllOfType(Action::ActionType::START)) {
     if (!isRegistered(action->getId())) {
       m_registered_players.push_back(action->getId());
-      EntityID player_id = initPlayer(m_em, m_server_com);
+      EntityID player_id = initPlayer(m_em, m_server_com, m_graphic_loader);
       action->setPlayerId(player_id);
     }
   }

--- a/Game/Systems/CreatePlayerSystem.hpp
+++ b/Game/Systems/CreatePlayerSystem.hpp
@@ -8,7 +8,8 @@
 class CreatePlayerSystem : public ISystem {
  public:
   CreatePlayerSystem(std::shared_ptr<EntityManager> t_em,
-                     UdpServer *t_server_com);
+                     UdpServer *t_server_com,
+                     rtype::IGraphicLoader *t_graphic_loader);
   ~CreatePlayerSystem() = default;
 
   void update();
@@ -19,6 +20,7 @@ class CreatePlayerSystem : public ISystem {
   EventQueue m_event_queue;
   UdpServer *m_server_com;
   std::vector<int> m_registered_players;
+  rtype::IGraphicLoader *m_graphic_loader;
 
   bool isRegistered(int t_id);
 };

--- a/Game/Systems/DamageSystem.cpp
+++ b/Game/Systems/DamageSystem.cpp
@@ -3,11 +3,13 @@
 DamageSystem::DamageSystem(std::shared_ptr<EntityManager> t_em,
                            InputManager &t_client_input_manager,
                            std::size_t t_port_number, bool &t_is_running,
-                           std::vector<SoundSystem::SoundType> &t_sounds)
+                           std::vector<SoundSystem::SoundType> &t_sounds,
+                           rtype::IGraphicLoader *t_graphic_loader)
     : m_client_input_manager(t_client_input_manager),
       m_is_running(t_is_running), m_play_sounds(t_sounds) {
   m_em = t_em;
   m_port_number = t_port_number;
+  m_graphic_loader = t_graphic_loader;
 }
 
 DamageSystem::~DamageSystem() {}
@@ -32,7 +34,8 @@ void DamageSystem::update() {
 
       SpriteECS health_new_bar =
         SpriteECS(player->health.healthbar
-                    .getSpritesPaths()[player->health.healthbar.getHealth()]);
+                    .getSpritesPaths()[player->health.healthbar.getHealth()],
+                  m_graphic_loader);
 
       player->health.body->setTexture(health_new_bar.getTexture());
     }

--- a/Game/Systems/DamageSystem.hpp
+++ b/Game/Systems/DamageSystem.hpp
@@ -16,7 +16,8 @@ class DamageSystem : public ISystem {
   DamageSystem(std::shared_ptr<EntityManager> t_em,
                InputManager &t_client_input_manager, std::size_t t_port_number,
                bool &t_is_running,
-               std::vector<SoundSystem::SoundType> &t_sounds);
+               std::vector<SoundSystem::SoundType> &t_sounds,
+               rtype::IGraphicLoader *t_graphic_loader);
   ~DamageSystem();
 
   virtual void update();
@@ -28,6 +29,7 @@ class DamageSystem : public ISystem {
   std::size_t m_port_number;
   bool &m_is_running;
   std::vector<SoundSystem::SoundType> &m_play_sounds;
+  rtype::IGraphicLoader *m_graphic_loader;
 };
 
 #endif  // CLIENT_SRC_SYSTEMS_DAMAGESYSTEM_HPP_

--- a/Game/Systems/PowerUpSystem.cpp
+++ b/Game/Systems/PowerUpSystem.cpp
@@ -1,9 +1,11 @@
 #include "PowerUpSystem.hpp"
 
 PowerUpSystem::PowerUpSystem(std::shared_ptr<EntityManager> t_em,
-                             std::vector<SoundSystem::SoundType> &t_sounds)
+                             std::vector<SoundSystem::SoundType> &t_sounds,
+                             rtype::IGraphicLoader *t_graphic_loader)
     : m_play_sounds(t_sounds) {
   m_em = t_em;
+  m_graphic_loader = t_graphic_loader;
 }
 
 PowerUpSystem::~PowerUpSystem() {}
@@ -53,7 +55,8 @@ void PowerUpSystem::increaseHealth(std::shared_ptr<Action> action) {
   }
   SpriteECS health_new_bar =
     SpriteECS(player->health.healthbar
-                .getSpritesPaths()[player->health.healthbar.getHealth()]);
+                .getSpritesPaths()[player->health.healthbar.getHealth()],
+              m_graphic_loader);
 
   player->health.body->setTexture(health_new_bar.getTexture());
 }

--- a/Game/Systems/PowerUpSystem.hpp
+++ b/Game/Systems/PowerUpSystem.hpp
@@ -9,7 +9,8 @@
 class PowerUpSystem : public ISystem {
  public:
   PowerUpSystem(std::shared_ptr<EntityManager> t_em,
-                std::vector<SoundSystem::SoundType> &t_sounds);
+                std::vector<SoundSystem::SoundType> &t_sounds,
+                rtype::IGraphicLoader *t_graphic_loader);
   ~PowerUpSystem();
 
   void update();
@@ -18,6 +19,7 @@ class PowerUpSystem : public ISystem {
  private:
   EventQueue m_event_queue;
   std::vector<SoundSystem::SoundType> &m_play_sounds;
+  rtype::IGraphicLoader *m_graphic_loader;
 
   void increaseHealth(std::shared_ptr<Action> action);
 };

--- a/Game/Systems/RandomEnemyGeneratorSystem.cpp
+++ b/Game/Systems/RandomEnemyGeneratorSystem.cpp
@@ -1,9 +1,11 @@
 #include "RandomEnemyGeneratorSystem.hpp"
 
 RandomEnemyGeneratorSystem::RandomEnemyGeneratorSystem(
-  std::shared_ptr<EntityManager> t_em, UdpServer *t_serverCom) {
+  std::shared_ptr<EntityManager> t_em, UdpServer *t_serverCom,
+  rtype::IGraphicLoader *t_graphic_loader) {
   m_em = t_em;
   m_serverCom = t_serverCom;
+  m_graphic_loader = t_graphic_loader;
 }
 
 RandomEnemyGeneratorSystem::~RandomEnemyGeneratorSystem() {}
@@ -19,11 +21,12 @@ void RandomEnemyGeneratorSystem::update() {
 void RandomEnemyGeneratorSystem::generateEnemy(int random) {
   if (random < 10) {
     EntityID enemy = m_em->createNewEntity();
-    SpriteECS sprite = SpriteECS("./../Client/sprites/r-typesheet30a.gif");
+    SpriteECS sprite =
+      SpriteECS("./../Client/sprites/r-typesheet30a.gif", m_graphic_loader);
     rtype::Vector2f enemy_pos = {800, float(rand() % 600 + 100)};
     float velocity_direction = float(rand() % 3 - 1);
 
-    rtype::IRectangleShape *body = new rtype::RectangleShape();
+    rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
     body->setSize({30, 30});
     body->setPosition({enemy_pos.x, enemy_pos.y});
     body->setTexture(sprite.getTexture());
@@ -64,10 +67,11 @@ void RandomEnemyGeneratorSystem::generatePowerUp(int random) {
 
 void RandomEnemyGeneratorSystem::createCoin() {
   EntityID powerup = m_em->createNewEntity();
-  SpriteECS sprite = SpriteECS("./../Client/sprites/powerup/coin.png");
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/powerup/coin.png", m_graphic_loader);
   rtype::Vector2f powerup_pos = {800, float(rand() % 600 + 100)};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({30, 30});
   body->setPosition({powerup_pos.x, powerup_pos.y});
   body->setTexture(sprite.getTexture());
@@ -89,10 +93,10 @@ void RandomEnemyGeneratorSystem::createItem(std::string t_path,
                                             rtype::ItemType t_type,
                                             int t_value) {
   EntityID powerup = m_em->createNewEntity();
-  SpriteECS sprite = SpriteECS(t_path);
+  SpriteECS sprite = SpriteECS(t_path, m_graphic_loader);
   rtype::Vector2f powerup_pos = {800, float(rand() % 600 + 100)};
 
-  rtype::IRectangleShape *body = new rtype::RectangleShape();
+  rtype::IRectangleShape *body = m_graphic_loader->loadRectangleShape();
   body->setSize({30, 30});
   body->setPosition({powerup_pos.x, powerup_pos.y});
   body->setTexture(sprite.getTexture());

--- a/Game/Systems/RandomEnemyGeneratorSystem.hpp
+++ b/Game/Systems/RandomEnemyGeneratorSystem.hpp
@@ -7,12 +7,12 @@
 #include "../ECS/ISystem.hpp"
 #include "../ECS/DataTypesECS.hpp"
 #include "../../Server/Protocol/UdpServer.hpp"
-#include "../Encapsulation/SFML/RectangleShape.hpp"
 
 class RandomEnemyGeneratorSystem : public ISystem {
  public:
   RandomEnemyGeneratorSystem(std::shared_ptr<EntityManager> t_em,
-                             UdpServer *t_serverCom);
+                             UdpServer *t_serverCom,
+                             rtype::IGraphicLoader *t_graphic_loader);
   ~RandomEnemyGeneratorSystem();
 
   void update();
@@ -21,6 +21,7 @@ class RandomEnemyGeneratorSystem : public ISystem {
  private:
   std::shared_ptr<EntityManager> m_em;
   UdpServer *m_serverCom;
+  rtype::IGraphicLoader *m_graphic_loader;
 
   void generateEnemy(int random);
   void generatePowerUp(int random);

--- a/Game/Systems/ShootingSystem.cpp
+++ b/Game/Systems/ShootingSystem.cpp
@@ -1,9 +1,11 @@
 #include "ShootingSystem.hpp"
 
 ShootingSystem::ShootingSystem(std::shared_ptr<EntityManager> t_em,
-                               UdpServer *t_serverCom) {
+                               UdpServer *t_serverCom,
+                               rtype::IGraphicLoader *t_graphic_loader) {
   m_em = t_em;
   m_serverCom = t_serverCom;
+  m_graphic_loader = t_graphic_loader;
 }
 
 ShootingSystem::~ShootingSystem() {}
@@ -34,11 +36,12 @@ void ShootingSystem::update() {
 void ShootingSystem::shoot(std::shared_ptr<Action> action) {
   Player *player = (*m_em.get()).Get<Player>(action->getId());
   EntityID bullet = m_em->createNewEntity();
-  SpriteECS sprite = SpriteECS("./../Client/sprites/shoot2.png");
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/shoot2.png", m_graphic_loader);
   rtype::Vector2f bullet_pos = {player->position.position.x - 20,
                                 player->position.position.y +
                                   player->body->getSize().y / 2 - 10};
-  rtype::IRectangleShape *bullet_body = new rtype::RectangleShape();
+  rtype::IRectangleShape *bullet_body = m_graphic_loader->loadRectangleShape();
 
   bullet_body->setSize({20, 20});
   bullet_body->setPosition({bullet_pos.x, bullet_pos.y});
@@ -59,11 +62,12 @@ void ShootingSystem::shootFire(std::shared_ptr<Action> action) {
 
   // TODO: replace by actual fire shoot
   EntityID bullet = m_em->createNewEntity();
-  SpriteECS sprite = SpriteECS("./../Client/sprites/shoot3.png");
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/shoot3.png", m_graphic_loader);
   rtype::Vector2f bullet_pos = {player->position.position.x - 20,
                                 player->position.position.y +
                                   player->body->getSize().y / 2 - 10};
-  rtype::IRectangleShape *bullet_body = new rtype::RectangleShape();
+  rtype::IRectangleShape *bullet_body = m_graphic_loader->loadRectangleShape();
 
   bullet_body->setSize({20, 20});
   bullet_body->setPosition({bullet_pos.x, bullet_pos.y});
@@ -84,11 +88,12 @@ void ShootingSystem::shootBomb(std::shared_ptr<Action> action) {
 
   // TODO: replace by actual bomb shoot
   EntityID bullet = m_em->createNewEntity();
-  SpriteECS sprite = SpriteECS("./../Client/sprites/shoot4.png");
+  SpriteECS sprite =
+    SpriteECS("./../Client/sprites/shoot4.png", m_graphic_loader);
   rtype::Vector2f bullet_pos = {player->position.position.x - 20,
                                 player->position.position.y +
                                   player->body->getSize().y / 2 - 10};
-  rtype::IRectangleShape *bullet_body = new rtype::RectangleShape();
+  rtype::IRectangleShape *bullet_body = m_graphic_loader->loadRectangleShape();
 
   bullet_body->setSize({20, 20});
   bullet_body->setPosition({bullet_pos.x, bullet_pos.y});

--- a/Game/Systems/ShootingSystem.hpp
+++ b/Game/Systems/ShootingSystem.hpp
@@ -9,7 +9,8 @@
 
 class ShootingSystem : public ISystem {
  public:
-  ShootingSystem(std::shared_ptr<EntityManager> t_em, UdpServer *t_serverCom);
+  ShootingSystem(std::shared_ptr<EntityManager> t_em, UdpServer *t_serverCom,
+                 rtype::IGraphicLoader *t_graphic_loader);
   ~ShootingSystem();
 
   void update();
@@ -18,6 +19,7 @@ class ShootingSystem : public ISystem {
  private:
   EventQueue m_event_queue;
   UdpServer *m_serverCom;
+  rtype::IGraphicLoader *m_graphic_loader;
 
   void shoot(std::shared_ptr<Action> action);
   void shootFire(std::shared_ptr<Action> action);

--- a/Game/Systems/SoundSystem.cpp
+++ b/Game/Systems/SoundSystem.cpp
@@ -1,10 +1,12 @@
 #include "SoundSystem.hpp"
 
 SoundSystem::SoundSystem(std::shared_ptr<EntityManager> t_em,
-                         std::vector<SoundType> &t_sounds)
+                         std::vector<SoundType> &t_sounds,
+                         rtype::IGraphicLoader *t_graphic_loader)
     : m_play_sounds(t_sounds) {
   m_em = t_em;
-  m_music = new rtype::Music();
+  m_graphic_loader = t_graphic_loader;
+  m_music = m_graphic_loader->loadMusic();
 
   // init music
   if (!m_music->openFromFile("../Client/assets/music/music2.ogg")) {
@@ -14,7 +16,7 @@ SoundSystem::SoundSystem(std::shared_ptr<EntityManager> t_em,
   m_music->setLoop(true);
   m_music->play();
 
-  m_sounds = new rtype::Sounds();
+  m_sounds = m_graphic_loader->loadSound();
   // init sounds - according to SoundType order
   m_sounds->addSoundFromFile("../Client/assets/sounds/shoot.wav");
   m_sounds->addSoundFromFile("../Client/assets/sounds/explosion.wav");

--- a/Game/Systems/SoundSystem.hpp
+++ b/Game/Systems/SoundSystem.hpp
@@ -5,15 +5,14 @@
 
 #include "../ECS/ISystem.hpp"
 #include "../Encapsulation/IMusic.hpp"
-#include "../Encapsulation/SFML/Music.hpp"
 #include "../Encapsulation/ISounds.hpp"
-#include "../Encapsulation/SFML/Sounds.hpp"
 
 class SoundSystem : public ISystem {
  public:
   enum SoundType { shoot, explosion, power_up, death, won };
   SoundSystem(std::shared_ptr<EntityManager> t_em,
-              std::vector<SoundType> &t_sounds);
+              std::vector<SoundType> &t_sounds,
+              rtype::IGraphicLoader *t_graphic_loader);
   ~SoundSystem();
 
   virtual void update();
@@ -22,6 +21,7 @@ class SoundSystem : public ISystem {
  private:
   rtype::IMusic *m_music;
   rtype::ISounds *m_sounds;
+  rtype::IGraphicLoader *m_graphic_loader;
 
   std::vector<SoundType> &m_play_sounds;
 };

--- a/GameEngine/src/Button.cpp
+++ b/GameEngine/src/Button.cpp
@@ -1,8 +1,9 @@
 #include "./Button.hpp"
 
 Button::Button(std::string t_path, rtype::Vector2f t_pos,
-               rtype::Vector2f t_target_size)
-    : Sprite(t_path, {t_pos.x, t_pos.y}) {
+               rtype::Vector2f t_target_size,
+               rtype::IGraphicLoader *t_graphic_loader)
+    : Sprite(t_path, {t_pos.x, t_pos.y}, t_graphic_loader) {
   float pos_x = t_target_size.x / getTexture()->getSize().x;
   float pos_y = t_target_size.y / getTexture()->getSize().y;
   getSprite()->setScale({pos_x, pos_y});

--- a/GameEngine/src/Button.hpp
+++ b/GameEngine/src/Button.hpp
@@ -13,7 +13,8 @@
 class Button : public Sprite {
  public:
   Button(std::string t_path, rtype::Vector2f t_pos,
-         rtype::Vector2f t_target_size);
+         rtype::Vector2f t_target_size,
+         rtype::IGraphicLoader *t_graphic_loader);
   bool is_pressed(rtype::Vector2f t_mouse_pos);
   bool is_hovered(rtype::Vector2f t_mouse_pos);
 };

--- a/GameEngine/src/Core.cpp
+++ b/GameEngine/src/Core.cpp
@@ -1,18 +1,22 @@
 #include "./Core.hpp"
 
 Core::Core(std::size_t t_flag) {
-  m_window = new rtype::RenderWindow();
+  m_graphic_loader = new rtype::GraphicLoader();
+  m_music_player.init(m_graphic_loader);
+  m_window = m_graphic_loader->loadRenderWindow();
   m_window->create(
     800, 800, t_flag == 0 ? "R-Type Server" : "R-Type Client",
     static_cast<rtype::Style>(rtype::Style::Titlebar | rtype::Style::Close));
   m_window->setFramerateLimit(60);
 
   if (t_flag == 1)
-    m_state_machine.run(StateMachine::build<MainState>(
-      m_state_machine, m_window, m_music_player, t_flag, true));
+    m_state_machine.run(
+      StateMachine::build<MainState>(m_state_machine, m_window, m_music_player,
+                                     t_flag, m_graphic_loader, true));
   else
-    m_state_machine.run(StateMachine::build<GameState>(
-      m_state_machine, m_window, m_music_player, t_flag, true));
+    m_state_machine.run(
+      StateMachine::build<GameState>(m_state_machine, m_window, m_music_player,
+                                     t_flag, m_graphic_loader, true));
 }
 
 Core::~Core() {}

--- a/GameEngine/src/Core.hpp
+++ b/GameEngine/src/Core.hpp
@@ -2,7 +2,8 @@
 #define CORE_HPP_
 
 #include "../../Game/Encapsulation/IRenderWindow.hpp"
-#include "../../Game/Encapsulation/SFML/RenderWindow.hpp"
+#include "../../Game/Encapsulation/IGraphicLoader.hpp"
+#include "../../Game/Encapsulation/SFML/GraphicLoader.hpp"
 #include "./States/MainState.hpp"
 #include "./MusicPlayer.hpp"
 #include "./StateMachine.hpp"
@@ -18,6 +19,7 @@ class Core {
   rtype::IRenderWindow *m_window;
   StateMachine m_state_machine;
   MusicPlayer m_music_player;
+  rtype::IGraphicLoader *m_graphic_loader;
 };
 
 #endif  // !CORE_HPP_

--- a/GameEngine/src/MusicPlayer.cpp
+++ b/GameEngine/src/MusicPlayer.cpp
@@ -1,14 +1,17 @@
 #include "./MusicPlayer.hpp"
 
-MusicPlayer::MusicPlayer() : m_volume(100.f) {
-  m_music = new rtype::Music();
+MusicPlayer::MusicPlayer() : m_volume(100.f) {}
+
+MusicPlayer::~MusicPlayer() { delete m_music; }
+
+void MusicPlayer::init(rtype::IGraphicLoader *t_graphic_loader) {
+  m_graphic_loader = t_graphic_loader;
+  m_music = m_graphic_loader->loadMusic();
   m_music->openFromFile("./assets/music/music1.ogg");
   m_music->openFromFile("./assets/music/music2.ogg");
   m_music->setLoop(true);
   m_music->setVolume(m_volume);
 }
-
-MusicPlayer::~MusicPlayer() { delete m_music; }
 
 void MusicPlayer::play(MusicID t_theme) { m_music->play(t_theme); }
 

--- a/GameEngine/src/MusicPlayer.hpp
+++ b/GameEngine/src/MusicPlayer.hpp
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <map>
 
-#include "../../Game/Encapsulation/SFML/Music.hpp"
 #include "../../Game/Encapsulation/IMusic.hpp"
+#include "../../Game/Encapsulation/IGraphicLoader.hpp"
 
 enum MusicID {
   MENU_THEME,
@@ -16,6 +16,7 @@ class MusicPlayer {
  public:
   MusicPlayer();
   ~MusicPlayer();
+  void init(rtype::IGraphicLoader *t_graphic_loader);
   void play(MusicID t_theme);
   void stop();
   void setPaused(bool t_paused);
@@ -24,6 +25,7 @@ class MusicPlayer {
  private:
   rtype::IMusic *m_music;
   float m_volume;
+  rtype::IGraphicLoader *m_graphic_loader;
 };
 
 #endif /* !MUSICPLAYER_HPP_ */

--- a/GameEngine/src/Sprite.cpp
+++ b/GameEngine/src/Sprite.cpp
@@ -1,8 +1,11 @@
 #include "./Sprite.hpp"
 
-Sprite::Sprite(std::string t_path, rtype::Vector2f t_pos) : m_path(t_path) {
-  m_texture = new rtype::Texture();
-  m_sprite = new rtype::Sprite();
+Sprite::Sprite(std::string t_path, rtype::Vector2f t_pos,
+               rtype::IGraphicLoader *t_graphic_loader)
+    : m_path(t_path) {
+  m_graphic_loader = t_graphic_loader;
+  m_texture = m_graphic_loader->loadTexture();
+  m_sprite = m_graphic_loader->loadSprite();
   if (!m_texture->loadFromFile(m_path))
     std::cout << "Can't find image: " << m_path << std::endl;
   m_sprite->setTexture(m_texture);

--- a/GameEngine/src/Sprite.hpp
+++ b/GameEngine/src/Sprite.hpp
@@ -7,12 +7,12 @@
 #include "../../Game/Encapsulation/GraphicDataTypes.hpp"
 #include "../../Game/Encapsulation/ISprite.hpp"
 #include "../../Game/Encapsulation/ITexture.hpp"
-#include "../../Game/Encapsulation/SFML/Sprite.hpp"
-#include "../../Game/Encapsulation/SFML/Texture.hpp"
+#include "../../Game/Encapsulation/IGraphicLoader.hpp"
 
 class Sprite {
  public:
-  Sprite(std::string t_path, rtype::Vector2f t_pos);
+  Sprite(std::string t_path, rtype::Vector2f t_pos,
+         rtype::IGraphicLoader *t_graphic_loader);
   ~Sprite();
   rtype::ISprite *getSprite();
   void setPos(float t_pos_x = 0, float t_pos_y = 0);
@@ -24,6 +24,7 @@ class Sprite {
   std::string m_path;
   rtype::ITexture *m_texture;
   rtype::ISprite *m_sprite;
+  rtype::IGraphicLoader *m_graphic_loader;
 };
 
 #endif  // !SPRITE_HPP_

--- a/GameEngine/src/State.cpp
+++ b/GameEngine/src/State.cpp
@@ -1,10 +1,12 @@
 #include "./State.hpp"
 
 State::State(StateMachine &t_machine, rtype::IRenderWindow *t_window,
-             MusicPlayer &t_music_player, const bool t_replace)
+             MusicPlayer &t_music_player,
+             rtype::IGraphicLoader *t_graphic_loader, const bool t_replace)
     : m_state_machine(t_machine), m_window(t_window),
       m_music_player(t_music_player), m_replace(t_replace) {
-  m_mouse = new rtype::Mouse();
+  m_graphic_loader = t_graphic_loader;
+  m_mouse = m_graphic_loader->loadMouse();
 }
 
 std::unique_ptr<State> State::next() { return std::move(m_next); }

--- a/GameEngine/src/State.hpp
+++ b/GameEngine/src/State.hpp
@@ -6,7 +6,7 @@
 #include "../../Game/Encapsulation/GraphicDataTypes.hpp"
 #include "../../Game/Encapsulation/IRenderWindow.hpp"
 #include "../../Game/Encapsulation/IMouse.hpp"
-#include "../../Game/Encapsulation/SFML/Mouse.hpp"
+#include "../../Game/Encapsulation/IGraphicLoader.hpp"
 #include "./MusicPlayer.hpp"
 
 class StateMachine;
@@ -14,7 +14,8 @@ class StateMachine;
 class State {
  public:
   State(StateMachine &t_machine, rtype::IRenderWindow *t_window,
-        MusicPlayer &t_music_player, bool t_replace = true);
+        MusicPlayer &t_music_player, rtype::IGraphicLoader *t_graphic_loader,
+        bool t_replace = true);
 
   virtual ~State() = default;
 
@@ -37,6 +38,7 @@ class State {
   MusicPlayer &m_music_player;
   bool m_replace;
   std::unique_ptr<State> m_next;
+  rtype::IGraphicLoader *m_graphic_loader;
 };
 
 #endif  // !STATE_HPP_

--- a/GameEngine/src/StateMachine.hpp
+++ b/GameEngine/src/StateMachine.hpp
@@ -21,10 +21,10 @@ class StateMachine {
   void lastState();
 
   template<typename T>
-  static std::unique_ptr<T> build(StateMachine &t_machine,
-                                  rtype::IRenderWindow *t_window,
-                                  MusicPlayer &t_music_playerbool,
-                                  std::size_t t_flag, bool t_replace = true);
+  static std::unique_ptr<T>
+  build(StateMachine &t_machine, rtype::IRenderWindow *t_window,
+        MusicPlayer &t_music_playerbool, std::size_t t_flag,
+        rtype::IGraphicLoader *t_graphic_loader, bool t_replace = true);
 
  private:
   bool m_running;
@@ -33,15 +33,15 @@ class StateMachine {
 };
 
 template<typename T>
-std::unique_ptr<T> StateMachine::build(StateMachine &t_machine,
-                                       rtype::IRenderWindow *t_window,
-                                       MusicPlayer &t_music_player,
-                                       std::size_t t_flag, bool t_replace) {
+std::unique_ptr<T>
+StateMachine::build(StateMachine &t_machine, rtype::IRenderWindow *t_window,
+                    MusicPlayer &t_music_player, std::size_t t_flag,
+                    rtype::IGraphicLoader *t_graphic_loader, bool t_replace) {
   auto new_state = std::unique_ptr<T>{nullptr};
 
   try {
     new_state = std::make_unique<T>(t_machine, t_window, t_music_player, t_flag,
-                                    t_replace);
+                                    t_graphic_loader, t_replace);
   } catch (std::runtime_error &exception) {
     std::cout << "Failed to create new State\n";
     std::cout << exception.what() << std::endl;

--- a/GameEngine/src/States/MainState.cpp
+++ b/GameEngine/src/States/MainState.cpp
@@ -2,21 +2,22 @@
 
 MainState::MainState(StateMachine &t_machine, rtype::IRenderWindow *t_window,
                      MusicPlayer &t_music_player, std::size_t t_flag,
+                     rtype::IGraphicLoader *t_graphic_loader,
                      const bool t_replace)
-    : State(t_machine, t_window, t_music_player, t_replace),
+    : State(t_machine, t_window, t_music_player, t_graphic_loader, t_replace),
       m_start_btn(Button(
         "./assets/startBtn.png",
         rtype::Vector2f{static_cast<float>(m_window->getSize().x / 2 - 135),
                         static_cast<float>(m_window->getSize().y / 2 - 65)},
-        rtype::Vector2f{270, 130})),
+        rtype::Vector2f{270, 130}, t_graphic_loader)),
       m_settings_btn(
         Button("./assets/gear.png",
                rtype::Vector2f{static_cast<float>(m_window->getSize().x - 100),
                                static_cast<float>(m_window->getSize().y - 100)},
-               rtype::Vector2f{64, 64})),
+               rtype::Vector2f{64, 64}, t_graphic_loader)),
       m_flag(t_flag) {
-  m_bg_t = new rtype::Texture();
-  m_bg_s = new rtype::Sprite();
+  m_bg_t = m_graphic_loader->loadTexture();
+  m_bg_s = m_graphic_loader->loadSprite();
   if (!m_bg_t->loadFromFile("./assets/menubg.jpg")) {
     throw std::runtime_error("Unable to load image.");
   }
@@ -46,12 +47,14 @@ void MainState::update() {
       if (m_start_btn.is_pressed(mouse_pos_f)) {
         std::cout << "startbtn pressed" << std::endl;
         m_next = StateMachine::build<GameState>(m_state_machine, m_window,
-                                                m_music_player, m_flag, true);
+                                                m_music_player, m_flag,
+                                                m_graphic_loader, true);
       }
       if (m_settings_btn.is_pressed(mouse_pos_f)) {
         std::cout << "settingsbtn pressed" << std::endl;
-        m_next = StateMachine::build<SettingsState>(
-          m_state_machine, m_window, m_music_player, m_flag, true);
+        m_next = StateMachine::build<SettingsState>(m_state_machine, m_window,
+                                                    m_music_player, m_flag,
+                                                    m_graphic_loader, true);
       }
     }
     switch (event.type) {

--- a/GameEngine/src/States/MainState.hpp
+++ b/GameEngine/src/States/MainState.hpp
@@ -4,9 +4,7 @@
 #include <iostream>
 
 #include "../../../Game/Encapsulation/ITexture.hpp"
-#include "../../../Game/Encapsulation/SFML/Texture.hpp"
 #include "../../../Game/Encapsulation/ISprite.hpp"
-#include "../../../Game/Encapsulation/SFML/Sprite.hpp"
 
 #include "../Button.hpp"
 #include "../MusicPlayer.hpp"
@@ -19,7 +17,7 @@ class MainState final : public State {
  public:
   MainState(StateMachine &t_machine, rtype::IRenderWindow *t_window,
             MusicPlayer &t_music_player, std::size_t t_flag,
-            bool t_replace = true);
+            rtype::IGraphicLoader *t_graphic_loader, bool t_replace = true);
   void pause() override;
   void resume() override;
   void update() override;

--- a/GameEngine/src/States/SettingsState.cpp
+++ b/GameEngine/src/States/SettingsState.cpp
@@ -3,16 +3,17 @@
 SettingsState::SettingsState(StateMachine &t_machine,
                              rtype::IRenderWindow *t_window,
                              MusicPlayer &t_music_player, std::size_t t_flag,
+                             rtype::IGraphicLoader *t_graphic_loader,
                              const bool t_replace)
-    : State(t_machine, t_window, t_music_player, t_replace),
+    : State(t_machine, t_window, t_music_player, t_graphic_loader, t_replace),
       m_start_btn(
         Button("./assets/startBtn.png",
                rtype::Vector2f{static_cast<float>(m_window->getSize().x - 320),
                                static_cast<float>(m_window->getSize().y - 180)},
-               rtype::Vector2f{270, 130})),
+               rtype::Vector2f{270, 130}, t_graphic_loader)),
       m_flag(t_flag) {
-  m_bg_t = new rtype::Texture();
-  m_bg_s = new rtype::Sprite();
+  m_bg_t = m_graphic_loader->loadTexture();
+  m_bg_s = m_graphic_loader->loadSprite();
   if (!m_bg_t->loadFromFile("./assets/menubg.jpg")) {
     throw std::runtime_error("Unable to load image.");
   }
@@ -40,7 +41,8 @@ void SettingsState::update() {
       if (m_start_btn.is_pressed(mouse_pos_f)) {
         std::cout << "startbtn pressed" << std::endl;
         m_next = StateMachine::build<MainState>(m_state_machine, m_window,
-                                                m_music_player, m_flag, true);
+                                                m_music_player, m_flag,
+                                                m_graphic_loader, true);
       }
     }
     switch (event.type) {
@@ -50,8 +52,9 @@ void SettingsState::update() {
       case rtype::EventType::KeyPressed:
         switch (event.key) {
           case rtype::EventKey::Space:
-            m_next = StateMachine::build<MainState>(
-              m_state_machine, m_window, m_music_player, m_flag, true);
+            m_next = StateMachine::build<MainState>(m_state_machine, m_window,
+                                                    m_music_player, m_flag,
+                                                    m_graphic_loader, true);
             break;
           case rtype::EventKey::Escape:
             m_state_machine.quit();

--- a/GameEngine/src/States/SettingsState.hpp
+++ b/GameEngine/src/States/SettingsState.hpp
@@ -5,9 +5,7 @@
 
 #include "../../../Game/Encapsulation/IRenderWindow.hpp"
 #include "../../../Game/Encapsulation/ITexture.hpp"
-#include "../../../Game/Encapsulation/SFML/Texture.hpp"
 #include "../../../Game/Encapsulation/ISprite.hpp"
-#include "../../../Game/Encapsulation/SFML/Sprite.hpp"
 
 #include "./MainState.hpp"
 #include "../Button.hpp"
@@ -18,7 +16,7 @@ class SettingsState final : public State {
  public:
   SettingsState(StateMachine &t_machine, rtype::IRenderWindow *t_window,
                 MusicPlayer &t_music_player, std::size_t t_flag,
-                bool t_replace = true);
+                rtype::IGraphicLoader *t_graphic_loader, bool t_replace = true);
   void pause() override;
   void resume() override;
   void update() override;


### PR DESCRIPTION
# Motivation:

Before, we created sfml objects instead of just referring to the interfaces. So at each point, the class needed to know, that sfml is the graphical library used.

# Modifications:

A graphic loader was created and is used everwhere, any object from sfml is created.

# Result:

Only in the core class, the Graphical loader will be identified as sfml, otherwise sfml isnt referred outside of the encapsulation folder anymore,